### PR TITLE
Force deploying of HA-SNO operator to the proper namespace

### DIFF
--- a/bundle/manifests/hasno-setup-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hasno-setup-operator.clusterserviceversion.yaml
@@ -53,6 +53,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operatorframework.io/suggested-namespace: ha-sno
   name: hasno-setup-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
Make sure ha-sno operator is deployed to the correct namespace.