### PR TITLE
Support configurable container image

### DIFF
--- a/api/v1alpha1/halayerset_types.go
+++ b/api/v1alpha1/halayerset_types.go
@@ -36,6 +36,9 @@ type HALayerSetSpec struct {
 
 	//NodesSpec contain names and ips of both SNO clusters nodes.
 	NodesSpec NodesSpec `json:"nodesSpec"`
+
+	//ContainerImage this image will be used by the HALayer pod to set up the pacemaker container which also contains the fencing agents - if left empty a default one will be used.
+	ContainerImage string `json:"containerImage,omitempty"`
 }
 
 // FenceAgentSpec contains the necessary information for setting up the fence agent that will be used in the HA layer.

--- a/api/v1alpha1/halayerset_webhook.go
+++ b/api/v1alpha1/halayerset_webhook.go
@@ -35,6 +35,7 @@ const (
 const (
 	nodeNameChangeErrorMsg          = "not allowed to change node name"
 	nodeIpChangeErrorMsg            = "not allowed to change node IP"
+	containerImageChangeErrorMsg    = "not allowed to change container image"
 	duplicateFenceAgentNameErrorMsg = "not allowed to have multiple fence agents with the same name"
 )
 
@@ -99,6 +100,10 @@ func (r *HALayerSet) ValidateUpdate(old runtime.Object) error {
 		return err
 	}
 
+	if err := validateContainerImage(oldCR, r); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -144,6 +149,15 @@ func validateFenceAgentUniqueness(r *HALayerSet) error {
 			return err
 		}
 		fenceAgentsNameSet[fenceAgentName] = setValuePlaceHolder
+	}
+	return nil
+}
+
+func validateContainerImage(oldCR *HALayerSet, r *HALayerSet) error {
+	if oldCR.Spec.ContainerImage != r.Spec.ContainerImage {
+		err := fmt.Errorf(containerImageChangeErrorMsg)
+		halayersetlog.Error(err, containerImageChangeErrorMsg, "original container image", oldCR.Spec.ContainerImage, "new container image", r.Spec.ContainerImage)
+		return err
 	}
 	return nil
 }

--- a/api/v1alpha1/halayerset_webhook_test.go
+++ b/api/v1alpha1/halayerset_webhook_test.go
@@ -105,6 +105,17 @@ var _ = Describe("HALayerSet Validation", func() {
 			})
 
 		})
+
+		Context("changing container image", func() {
+			It("should fail", func() { //First Node IP
+				haOld, haNew := createHALayerSetCR(), createHALayerSetCR()
+				haNew.Spec.ContainerImage = "io.quay/mock-new-image/0.0.1"
+				err := haNew.ValidateUpdate(haOld)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(containerImageChangeErrorMsg))
+			})
+
+		})
 	})
 })
 

--- a/bundle/manifests/ha-sno.medik8s.io_halayersets.yaml
+++ b/bundle/manifests/ha-sno.medik8s.io_halayersets.yaml
@@ -45,6 +45,11 @@ spec:
           spec:
             description: HALayerSetSpec defines the desired state of HALayerSet
             properties:
+              containerImage:
+                description: ContainerImage this image will be used by the HALayer
+                  pod to set up the pacemaker container which also contains the fencing
+                  agents - if left empty a default one will be used.
+                type: string
               deployments:
                 description: Deployments is a list of deployments that will be managed
                   by the created HA layer.

--- a/bundle/manifests/hasno-setup-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hasno-setup-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
             "name": "halayerset-sample"
           },
           "spec": {
+            "containerImage": "quay.io/mshitrit/pcmk:v3",
             "deployments": [
               "nginx-test",
               "nginx-prod"

--- a/config/crd/bases/ha-sno.medik8s.io_halayersets.yaml
+++ b/config/crd/bases/ha-sno.medik8s.io_halayersets.yaml
@@ -36,6 +36,11 @@ spec:
           spec:
             description: HALayerSetSpec defines the desired state of HALayerSet
             properties:
+              containerImage:
+                description: ContainerImage this image will be used by the HALayer
+                  pod to set up the pacemaker container which also contains the fencing
+                  agents - if left empty a default one will be used.
+                type: string
               deployments:
                 description: Deployments is a list of deployments that will be managed
                   by the created HA layer.

--- a/config/samples/ha-sno_v1alpha1_halayerset.yaml
+++ b/config/samples/ha-sno_v1alpha1_halayerset.yaml
@@ -31,3 +31,4 @@ spec:
     firstNodeIP: "192.168.126.10"
     secondNodeName: "cluster2"
     secondNodeIP: "192.168.126.11"
+  containerImage: "quay.io/mshitrit/pcmk:v3"

--- a/controllers/halayerset_controller.go
+++ b/controllers/halayerset_controller.go
@@ -62,6 +62,7 @@ const (
 	serviceAccountName = "hasno-setup-operator-aio-cluster-role"
 
 	deploymentNamespaceEnvVar = "DEPLOYMENT_NAMESPACE"
+	defaultContainerImage = "quay.io/mshitrit/pcmk:v3"
 )
 
 var (
@@ -332,8 +333,9 @@ func (r *HALayerSetReconciler) buildHALayerPod(hals *v1alpha1.HALayerSet, nodeNa
 		{IP: hals.Spec.NodesSpec.SecondNodeIP, Hostnames: []string{hals.Spec.NodesSpec.SecondNodeName}},
 	}
 	trueVal := true
+	containerImage := r.getContainerImage(hals)
 	pod.Spec.Containers = []corev1.Container{
-		{Name: "system", Image: "quay.io/mshitrit/pcmk:v3", ImagePullPolicy: corev1.PullAlways, Command: []string{"/usr/lib/systemd/systemd", "--system"},
+		{Name: "system", Image: containerImage, ImagePullPolicy: corev1.PullAlways, Command: []string{"/usr/lib/systemd/systemd", "--system"},
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "cluster-state", MountPath: "/var/lib/pcsd"},
 				{Name: "cluster-state", MountPath: "/etc/corosync"},
@@ -342,12 +344,12 @@ func (r *HALayerSetReconciler) buildHALayerPod(hals *v1alpha1.HALayerSet, nodeNa
 			SecurityContext: &corev1.SecurityContext{Privileged: &trueVal},
 		},
 
-		{Name: "corosync", Image: "quay.io/mshitrit/pcmk:v3", ImagePullPolicy: corev1.PullAlways, Command: []string{"/usr/sbin/corosync", "-f"},
+		{Name: "corosync", Image: containerImage, ImagePullPolicy: corev1.PullAlways, Command: []string{"/usr/sbin/corosync", "-f"},
 			VolumeMounts:    []corev1.VolumeMount{{Name: "cluster-state", MountPath: "/etc/corosync"}},
 			SecurityContext: &corev1.SecurityContext{Privileged: &trueVal},
 		},
 
-		{Name: "pacemaker", Image: "quay.io/mshitrit/pcmk:v3", ImagePullPolicy: corev1.PullAlways, Command: []string{"/usr/sbin/pacemakerd", "-f"},
+		{Name: "pacemaker", Image: containerImage, ImagePullPolicy: corev1.PullAlways, Command: []string{"/usr/sbin/pacemakerd", "-f"},
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "cluster-state", MountPath: "/etc/pacemaker"},
 				{Name: "cluster-state", MountPath: "/var/lib/pacemaker"},
@@ -357,7 +359,7 @@ func (r *HALayerSetReconciler) buildHALayerPod(hals *v1alpha1.HALayerSet, nodeNa
 	}
 
 	pod.Spec.InitContainers = []corev1.Container{
-		{Name: "init", Image: "quay.io/mshitrit/pcmk:v3", ImagePullPolicy: corev1.PullAlways, Command: []string{"/root/setup.sh"},
+		{Name: "init", Image: containerImage, ImagePullPolicy: corev1.PullAlways, Command: []string{"/root/setup.sh"},
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "cluster-state", MountPath: "/etc/corosync"},
 				{Name: "cluster-state", MountPath: "/etc/pacemaker"},
@@ -380,6 +382,22 @@ func (r *HALayerSetReconciler) buildHALayerPod(hals *v1alpha1.HALayerSet, nodeNa
 		},
 	}
 	return pod
+}
+
+func (r *HALayerSetReconciler) getContainerImage(hals *v1alpha1.HALayerSet) string {
+	var containerImage string
+	if len(hals.Spec.ContainerImage) > 0 {
+		containerImage = hals.Spec.ContainerImage
+	} else {
+		containerImage = defaultContainerImage
+	}
+
+	if containerImage == defaultContainerImage {
+		r.Log.Info("haLayer pod is using default container image", "image", containerImage)
+	} else {
+		r.Log.Info("haLayer pod is using a user customized container image", "image", containerImage)
+	}
+	return containerImage
 }
 
 func (r *HALayerSetReconciler) deleteHAService(namespace string) error {


### PR DESCRIPTION
The HALayer pod contains a container image which is running the pacemaker and supports the fence agent.
In this PR we allow the user to configure which container image to use (for example in case the user requires a fence agent that is not supported by the default container image).
- In case nothing is configured we will use the default container image.
- At the moment we only support this on pod creation and not on update.

[Jira Ticket](https://issues.redhat.com/browse/ECOPROJECT-363)